### PR TITLE
Fix a typo in the counter example

### DIFF
--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -1,7 +1,7 @@
 use vizia::*;
 
 const STYLE: &str = r#"
-    botton {
+    button {
         width: 100px;
         height: 30px;
     }


### PR DESCRIPTION
This PR changes ``botton`` to ``button`` in the [counter](https://github.com/geom3trik/VIZIA/blob/main/examples/counter.rs) example.