### PR TITLE
Make lenses fallible

### DIFF
--- a/core/src/state/binding.rs
+++ b/core/src/state/binding.rs
@@ -36,14 +36,17 @@ where
     {
         Self::new(cx, lens, move |cx, field| {
             let some = field.get_fallible(cx).is_some();
-            let (stored_some, stored_count) = cx.data
+            let (stored_some, stored_count) = cx
+                .data
                 .get(cx.current)
                 .and_then(|store| store.data.get(&TypeId::of::<FallibleMarker>()))
                 .and_then(|dat| dat.downcast_ref::<FallibleMarker>())
                 .map(|dat| (dat.0, dat.1))
                 .unwrap_or((false, 0));
             if some != stored_some {
-                for child in cx.current.child_iter(&cx.tree)
+                for child in cx
+                    .current
+                    .child_iter(&cx.tree)
                     .enumerate()
                     .filter(|(idx, _)| *idx >= cx.count && *idx < cx.count + stored_count)
                     .map(|(_, e)| e)

--- a/core/src/state/lens.rs
+++ b/core/src/state/lens.rs
@@ -11,7 +11,7 @@ pub trait Lens: 'static + Clone + Copy + std::fmt::Debug {
     type Source: Model;
     type Target;
 
-    fn view<'a>(&self, source: &'a Self::Source) -> &'a Self::Target;
+    fn view<'a>(&self, source: &'a Self::Source) -> Option<&'a Self::Target>;
 }
 
 /// Helpers for constructing more complex `Lens`es.
@@ -81,8 +81,8 @@ where
     type Source = A::Source;
     type Target = B::Target;
 
-    fn view<'a>(&self, data: &'a Self::Source) -> &'a Self::Target {
-        &self.b.view(&self.a.view(data))
+    fn view<'a>(&self, data: &'a Self::Source) -> Option<&'a Self::Target> {
+        self.a.view(data).and_then(|intermediate| self.b.view(intermediate))
     }
 }
 
@@ -145,8 +145,8 @@ impl<T> Lens for StaticLens<T> {
     type Source = ();
     type Target = T;
 
-    fn view<'a>(&self, _source: &'a Self::Source) -> &'a Self::Target {
-        self.data
+    fn view<'a>(&self, _source: &'a Self::Source) -> Option<&'a Self::Target> {
+        Some(self.data)
     }
 }
 

--- a/core/src/state/lens.rs
+++ b/core/src/state/lens.rs
@@ -29,7 +29,7 @@ pub trait LensExt: Lens {
     /// ```
     fn then<Other>(self, other: Other) -> Then<Self, Other>
     where
-        Other: Lens + Sized,
+        Other: Lens<Source = Self::Target> + Sized,
         Self: Sized,
     {
         Then::new(self, other)

--- a/core/src/state/lens.rs
+++ b/core/src/state/lens.rs
@@ -99,21 +99,13 @@ pub struct Index<L, O> {
 
 impl<L, O> Index<L, O> {
     pub fn new(input: L, index: usize) -> Self {
-        Self {
-            index,
-            input,
-            output: PhantomData::default(),
-        }
+        Self { index, input, output: PhantomData::default() }
     }
 }
 
 impl<L: Clone, O> Clone for Index<L, O> {
     fn clone(&self) -> Self {
-        Self {
-            index: self.index.clone(),
-            input: self.input.clone(),
-            output: Default::default(),
-        }
+        Self { index: self.index.clone(), input: self.input.clone(), output: Default::default() }
     }
 }
 
@@ -121,10 +113,7 @@ impl<L: Copy, O> Copy for Index<L, O> {}
 
 impl<L: Debug, O> Debug for Index<L, O> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Index")
-            .field("index", &self.index)
-            .field("input", &self.input)
-            .finish()
+        f.debug_struct("Index").field("index", &self.index).field("input", &self.input).finish()
     }
 }
 

--- a/core/src/views/list.rs
+++ b/core/src/views/list.rs
@@ -65,6 +65,7 @@ where
     {
         self.lens
             .view(cx.data().expect("Failed to get data"))
+            .expect("Failed to view data")
             .get(self.index)
             .expect(&format!("Failed to get item: {}", self.index))
     }

--- a/core/src/views/table.rs
+++ b/core/src/views/table.rs
@@ -55,7 +55,7 @@ where
         }
 
         if let Some(data) = found_data {
-            let len = self.lens.view(data).len();
+            let len = self.lens.view(data).unwrap().len();
 
             assert!(len / self.width == self.width, "Only square tables supported at the moment");
 

--- a/core/src/views/textbox.rs
+++ b/core/src/views/textbox.rs
@@ -316,7 +316,7 @@ where
 
     pub fn get_text<'a>(&self, cx: &'a Context) -> Option<&'a T> {
         if let Some(source) = cx.data::<L::Source>() {
-            return Some(self.lens.view(source));
+            return Some(self.lens.view(source).unwrap());
         }
 
         None

--- a/derive/src/lens.rs
+++ b/derive/src/lens.rs
@@ -154,8 +154,8 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
                 type Source = #struct_type#ty_generics;
                 type Target = #field_ty;
 
-                fn view<'a>(&self, data: &'a#struct_type#ty_generics) -> &'a#field_ty {
-                    &data.#field_name
+                fn view<'a>(&self, data: &'a#struct_type#ty_generics) -> Option<&'a#field_ty> {
+                    Some(&data.#field_name)
                 }
             }
         }
@@ -193,8 +193,8 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
             type Source = #struct_type#ty_generics;
             type Target = #struct_type#ty_generics;
 
-            fn view<'a>(&self, source: &'a Self::Source) -> &'a Self::Target {
-                source
+            fn view<'a>(&self, source: &'a Self::Source) -> Option<&'a Self::Target> {
+                Some(source)
             }
         }
 

--- a/examples/optional_data.rs
+++ b/examples/optional_data.rs
@@ -1,0 +1,54 @@
+
+
+use vizia::*;
+
+#[derive(Lens)]
+pub struct AppData {
+    data: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum AppEvent {
+    AddData,
+    ClearData,
+}
+
+impl Model for AppData {
+    fn event(&mut self, cx: &mut Context, event: &mut Event) {
+        if let Some(app_event) = event.message.downcast() {
+            match app_event {
+                AppEvent::AddData => {
+                    self.data = Some("Hello World".to_string());
+                }
+
+                AppEvent::ClearData => {
+                    println!("Clear");
+                    self.data = None;
+                }
+            }
+        }
+    }
+}
+
+fn main() {
+    let window_description = WindowDescription::new();
+    Application::new(window_description, |cx|{
+
+        AppData {
+            data: Some("Hello World".to_string()),
+        }.build(cx);
+
+        Binding::new_fallible(cx, AppData::data, |cx, text|{
+            println!("Something");
+            if let Some(text) = text.get(cx).clone() {
+                Label::new(cx, &text);
+            }
+        }, |cx|{
+            println!("Nothing");
+        });
+
+        Button::new(cx, |cx| cx.emit(AppEvent::ClearData), |cx|{
+            Label::new(cx, "Clear")
+        });
+    }).run();
+}


### PR DESCRIPTION
As outlined on discord, this makes it so that Lens::view returns Option<'&a Self::Target>. This is mostly abstracted away by adding an unwrap() in Field::get. This can be interacted with safely by using Binding::new_fallible, which has a TODO which I will need some help resolving.