### PR TITLE
Print warning on unknown rules, do not rebuild application on f5

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -236,7 +236,7 @@ impl Context {
 
         self.style.parse_theme(&overall_theme);
 
-        self.enviroment.needs_rebuild = true;
+        // self.enviroment.needs_rebuild = true;
 
         // Entity::root().restyle(self);
         // Entity::root().relayout(self);

--- a/core/src/style/mod.rs
+++ b/core/src/style/mod.rs
@@ -977,6 +977,10 @@ impl Style {
                         }
                     }
 
+                    Property::Unknown(s, _) => {
+                        println!("Unknown style property: {}", s)
+                    }
+
                     _ => {}
                 }
             }


### PR DESCRIPTION
Two changes which I found helpful while debugging my application.

- first change is self-explanitory
- second change is specifically motivated by a) being annoyed that my state would reset whenever I hit f5 (the element I was trying to style is not visible by default in my app) and b) noticing that once I added the first change, messages would appear a quadratically increasing number of times each time I hit f5 - each rebuild loads a new theme without clearing the old themes. I don't know if you also want to add logic clearing the user themes and stylesheets to the application logic that rebuilds everything, but this seemed like the easiest solution.