### PR TITLE
Add Context::spawn for spawning threads that can emit events

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, VecDeque};
+use std::fmt::{Debug, Display, Formatter};
 
 #[cfg(feature = "clipboard")]
 use copypasta::ClipboardContext;
@@ -269,10 +270,24 @@ pub struct ContextProxy {
     pub event_proxy: Option<Box<dyn EventProxy>>,
 }
 
+#[derive(Debug)]
 pub enum ProxyEmitError {
     Unsupported,
     EventLoopClosed,
 }
+
+impl Display for ProxyEmitError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProxyEmitError::Unsupported =>
+                f.write_str("The current runtime does not support proxying events"),
+            ProxyEmitError::EventLoopClosed =>
+                f.write_str("Sending an event to an event loop which has been closed")
+        }
+    }
+}
+
+impl std::error::Error for ProxyEmitError {}
 
 impl ContextProxy {
     pub fn emit<M: Message>(&mut self, message: M) -> Result<(), ProxyEmitError> {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -39,6 +39,8 @@ pub struct Context {
 
     pub text_context: TextContext,
 
+    pub event_proxy: Option<Box<dyn EventProxy>>,
+
     #[cfg(feature = "clipboard")]
     pub clipboard: ClipboardContext,
 }
@@ -67,6 +69,8 @@ impl Context {
             focused: Entity::root(),
             resource_manager: ResourceManager::new(),
             text_context: TextContext::default(),
+
+            event_proxy: None,
 
             #[cfg(feature = "clipboard")]
             clipboard: ClipboardContext::new().expect("Failed to init clipboard"),
@@ -246,4 +250,59 @@ impl Context {
 
         Ok(())
     }
+
+    pub fn spawn<F>(&self, target: F) where F: 'static + Send + Fn(&mut ContextProxy) {
+        let mut cxp = ContextProxy {
+            current: self.current,
+            event_proxy: self.event_proxy.as_ref().map(|p| p.make_clone())
+        };
+
+        std::thread::spawn(move || target(&mut cxp));
+    }
+}
+
+/// A bundle of data representing a snapshot of the context when a thread was spawned. It supports
+/// a small subset of context operations. You will get one of these passed to you when you create a
+/// new thread with `cx.spawn()`.
+pub struct ContextProxy {
+    pub current: Entity,
+    pub event_proxy: Option<Box<dyn EventProxy>>,
+}
+
+pub enum ProxyEmitError {
+    Unsupported,
+    EventLoopClosed,
+}
+
+impl ContextProxy {
+    pub fn emit<M: Message>(&mut self, message: M) -> Result<(), ProxyEmitError> {
+        if let Some(proxy) = &self.event_proxy {
+            let event = Event::new(message)
+                .target(self.current)
+                .origin(self.current)
+                .propagate(Propagation::Up);
+
+            proxy.send(event).map_err(|_| ProxyEmitError::EventLoopClosed)
+        } else {
+            Err(ProxyEmitError::Unsupported)
+        }
+    }
+
+    pub fn emit_to<M: Message>(&mut self, target: Entity, message: M) -> Result<(), ProxyEmitError> {
+        if let Some(proxy) = &self.event_proxy {
+            let event = Event::new(message)
+                .target(target)
+                .origin(self.current)
+                .propagate(Propagation::Direct);
+
+            proxy.send(event).map_err(|_| ProxyEmitError::EventLoopClosed)
+        } else {
+            Err(ProxyEmitError::Unsupported)
+        }
+    }
+}
+
+pub trait EventProxy: Send {
+    fn send(&self, event: Event) -> Result<(), ()>;
+    fn make_clone(&self) -> Box<dyn EventProxy>;
 }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -252,10 +252,13 @@ impl Context {
         Ok(())
     }
 
-    pub fn spawn<F>(&self, target: F) where F: 'static + Send + Fn(&mut ContextProxy) {
+    pub fn spawn<F>(&self, target: F)
+    where
+        F: 'static + Send + Fn(&mut ContextProxy),
+    {
         let mut cxp = ContextProxy {
             current: self.current,
-            event_proxy: self.event_proxy.as_ref().map(|p| p.make_clone())
+            event_proxy: self.event_proxy.as_ref().map(|p| p.make_clone()),
         };
 
         std::thread::spawn(move || target(&mut cxp));
@@ -279,10 +282,12 @@ pub enum ProxyEmitError {
 impl Display for ProxyEmitError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            ProxyEmitError::Unsupported =>
-                f.write_str("The current runtime does not support proxying events"),
-            ProxyEmitError::EventLoopClosed =>
+            ProxyEmitError::Unsupported => {
+                f.write_str("The current runtime does not support proxying events")
+            }
+            ProxyEmitError::EventLoopClosed => {
                 f.write_str("Sending an event to an event loop which has been closed")
+            }
         }
     }
 }
@@ -303,7 +308,11 @@ impl ContextProxy {
         }
     }
 
-    pub fn emit_to<M: Message>(&mut self, target: Entity, message: M) -> Result<(), ProxyEmitError> {
+    pub fn emit_to<M: Message>(
+        &mut self,
+        target: Entity,
+        message: M,
+    ) -> Result<(), ProxyEmitError> {
         if let Some(proxy) = &self.event_proxy {
             let event = Event::new(message)
                 .target(target)

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -11,5 +11,5 @@ description = "Glutin backend for vizia"
 glutin = "0.28.0"
 femtovg = {version = "0.3.0", default-features = false, features = ["glutin"]}
 keyboard-types = { version = "0.5.0", default-features = false }
-vizia_core = { path = "../core", version = "0.1"}
+vizia_core = { path = "../core", version = "0.1" }
 fnv = "1.0.7"

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -19,6 +19,18 @@ pub struct Application {
     should_poll: bool,
 }
 
+pub struct GlutinEventProxy(EventLoopProxy<Event>);
+
+impl EventProxy for GlutinEventProxy {
+    fn send(&self, event: Event) -> Result<(), ()> {
+        self.0.send_event(event).map_err(|_| ())
+    }
+
+    fn make_clone(&self) -> Box<dyn EventProxy> {
+        Box::new(GlutinEventProxy(self.0.clone()))
+    }
+}
+
 impl Application {
     pub fn new<F>(window_description: WindowDescription, builder: F) -> Self
     where
@@ -30,9 +42,13 @@ impl Application {
 
         context.add_theme(DEFAULT_THEME);
 
+        let event_loop = EventLoop::with_user_event();
+        let event_proxy_obj = event_loop.create_proxy();
+        context.event_proxy = Some(Box::new(GlutinEventProxy(event_proxy_obj)));
+
         Self {
             context,
-            event_loop: EventLoop::with_user_event(),
+            event_loop,
             builder: Some(Box::new(builder)),
             on_idle: None,
             window_description,


### PR DESCRIPTION
Sample usage is:

```rust
cx.spawn(|cx| {
    if let Some(map) = load_workflow() {
        cx.emit(AppEvent::Load { map: RefCell::new(Some(map)) });
    }
})
```