### PR TITLE
Remove a few static bounds

### DIFF
--- a/core/src/view.rs
+++ b/core/src/view.rs
@@ -18,7 +18,7 @@ pub trait View: 'static + Sized {
     fn body(&mut self, cx: &mut Context) {}
     fn build2<F>(self, cx: &mut Context, builder: F) -> Handle<Self>
     where
-        F: 'static + FnOnce(&mut Context),
+        F: FnOnce(&mut Context),
     {
         // Add the instance to context unless it already exists
         let id = if let Some(id) = cx.tree.get_child(cx.current, cx.count) {

--- a/core/src/views/stack.rs
+++ b/core/src/views/stack.rs
@@ -10,7 +10,7 @@ pub struct VStack {}
 impl VStack {
     pub fn new<'a, F>(cx: &'a mut Context, content: F) -> Handle<Self>
     where
-        F: 'static + FnOnce(&mut Context),
+        F: FnOnce(&mut Context),
     {
         Self {}.build2(cx, |cx| {
             (content)(cx);
@@ -30,7 +30,7 @@ pub struct HStack {}
 impl HStack {
     pub fn new<F>(cx: &mut Context, content: F) -> Handle<Self>
     where
-        F: 'static + FnOnce(&mut Context),
+        F: FnOnce(&mut Context),
     {
         Self {}
             .build2(cx, |cx| {
@@ -52,7 +52,7 @@ pub struct ZStack {}
 impl ZStack {
     pub fn new<F>(cx: &mut Context, content: F) -> Handle<Self>
     where
-        F: 'static + FnOnce(&mut Context),
+        F: FnOnce(&mut Context),
     {
         Self {}.build2(cx, |cx| {
             (content)(cx);


### PR DESCRIPTION
Getting rid of these bounds enables better ergonomics and fewer clones (especially in the rebuild-always branch) at no penalty.