### PR TITLE
Move Model trait bound off of Lens declaration

### DIFF
--- a/core/src/state/binding.rs
+++ b/core/src/state/binding.rs
@@ -22,7 +22,7 @@ where
 impl<L> Binding<L>
 where
     L: 'static + Lens,
-    <L as Lens>::Source: 'static,
+    <L as Lens>::Source: 'static + Model,
     <L as Lens>::Target: Data,
 {
     pub fn new<F>(cx: &mut Context, lens: L, builder: F)

--- a/core/src/state/lens.rs
+++ b/core/src/state/lens.rs
@@ -10,7 +10,7 @@ use std::ops::Deref;
 /// The `view()` method takes a reference to the struct type as input and outputs a reference to the field.
 /// This provides a way to specify a binding to a specific field of some application data.
 pub trait Lens: 'static + Clone + Copy + std::fmt::Debug {
-    type Source: Model;
+    type Source;
     type Target;
 
     fn view<'a>(&self, source: &'a Self::Source) -> &'a Self::Target;
@@ -133,7 +133,6 @@ where
     L: Lens<Source = I, Target = M>,
     M: 'static + Deref<Target = [O]>,
     O: 'static,
-    I: Model,
 {
     type Source = I;
     type Target = O;

--- a/core/src/views/picker.rs
+++ b/core/src/views/picker.rs
@@ -16,7 +16,7 @@ where
 impl<L> Picker<L>
 where
     L: 'static + Lens,
-    <L as Lens>::Source: 'static,
+    <L as Lens>::Source: 'static + Model,
     <L as Lens>::Target: Data,
 {
     pub fn new<F>(cx: &mut Context, lens: L, builder: F) -> Handle<Self>


### PR DESCRIPTION
When you do Data::one.then(One::two), you don't need One to be a model.